### PR TITLE
Fix "nvalid Given/Family Name" bug

### DIFF
--- a/lib/google_syncinator.rb
+++ b/lib/google_syncinator.rb
@@ -38,6 +38,7 @@ module GoogleSyncinator
     require './lib/log'
     require './lib/service_objects'
     require './lib/trogdir_change'
+    require './lib/trogdir_person'
     require './lib/unique_email_address'
     require './lib/whitelist'
     require './lib/workers'

--- a/lib/service_objects/sync_google_account.rb
+++ b/lib/service_objects/sync_google_account.rb
@@ -1,7 +1,8 @@
 module ServiceObjects
   class SyncGoogleAccount < Base
     def call
-      google_account.create_or_update!(change.first_name, change.last_name, change.department, change.title, change.privacy)
+      person = TrogdirPerson.new(change.person_uuid)
+      google_account.create_or_update!(person.first_name, person.last_name, person.department, person.title, person.privacy)
     end
 
     def ignore?

--- a/lib/trogdir_person.rb
+++ b/lib/trogdir_person.rb
@@ -1,0 +1,24 @@
+class TrogdirPerson
+  class TrogdirAPIError < StandardError; end
+  attr_reader :uuid
+
+  def initialize(uuid)
+    @uuid = uuid
+  end
+
+  %w(first_name last_name department title privacy).each do |m|
+    define_method(m) do
+      hash[m]
+    end
+  end
+
+  private
+
+  def hash
+    @hash ||= (
+      response = Trogdir::APIClient::People.new.show(uuid: uuid).perform
+      raise TrogdirAPIError, response.parse['error'] unless response.success?
+      response.parse
+    )
+  end
+end


### PR DESCRIPTION
We were trying to sync from a create email change that doesn't have the person info we need to create accounts in google. So instead we'll just grab the person info directly from trogdir.