### PR TITLE
Use affiliations from changeset if they exist

### DIFF
--- a/lib/trogdir_change.rb
+++ b/lib/trogdir_change.rb
@@ -41,7 +41,11 @@ class TrogdirChange
   end
 
   def affiliations
-    all_attrs['affiliations']
+    if modified.has_key? 'affiliations'
+      modified['affiliations']
+    else
+      all_attrs['affiliations']
+    end
   end
 
   def privacy


### PR DESCRIPTION
This fixes an issue where two change_syncs would be started at the same time and google-syncinator would think both were adding an affiliation because it was looking at all_attributes.