### PR TITLE
Skip leave/join if unnecessary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+/certs/*
 *.p12
 .bundle
 /config/settings.local.yml
 /config/blazing.rb
 /vendor/bundle
 /tmp
+/log/*

--- a/lib/service_objects/join_google_group.rb
+++ b/lib/service_objects/join_google_group.rb
@@ -2,10 +2,10 @@ module ServiceObjects
   class JoinGoogleGroup < Base
     def call
       changes = Whitelist.filter(change.joined_groups).each do |group|
-        google_account.join! group
+        changed = true if google_account.join! group
       end
 
-      changes.any? ? :update : :skip
+      changes.any? && changed ? :update : :skip
     end
 
     def ignore?

--- a/lib/service_objects/join_google_group.rb
+++ b/lib/service_objects/join_google_group.rb
@@ -2,10 +2,10 @@ module ServiceObjects
   class JoinGoogleGroup < Base
     def call
       changes = Whitelist.filter(change.joined_groups).each do |group|
-        changed = true if google_account.join! group
+        @changed = true if google_account.join! group
       end
 
-      changes.any? && changed ? :update : :skip
+      changes.any? && @changed ? :update : :skip
     end
 
     def ignore?

--- a/lib/service_objects/leave_google_group.rb
+++ b/lib/service_objects/leave_google_group.rb
@@ -2,10 +2,10 @@ module ServiceObjects
   class LeaveGoogleGroup < Base
     def call
       changes = Whitelist.filter(change.left_groups).each do |group|
-        changed = true if google_account.leave! group
+        @changed = true if google_account.leave! group
       end
 
-      changes.any? && changed ? :update : :skip
+      changes.any? && @changed ? :update : :skip
     end
 
     def ignore?

--- a/lib/service_objects/leave_google_group.rb
+++ b/lib/service_objects/leave_google_group.rb
@@ -2,10 +2,10 @@ module ServiceObjects
   class LeaveGoogleGroup < Base
     def call
       changes = Whitelist.filter(change.left_groups).each do |group|
-        google_account.leave! group
+        changed = true if google_account.leave! group
       end
 
-      changes.any? ? :update : :skip
+      changes.any? && changed ? :update : :skip
     end
 
     def ignore?


### PR DESCRIPTION
If the user already is a member of a group or is already removed from a
group, we should not be throwing an error, we should be skipping. This
will lookup a member in a group and not attempt to insert/remove that
member if they exist/don't respectively. The status of a skipped
insert/removal should be reflected in trogdir.