### PR TITLE
When a user's biola_id updates, it should update

### DIFF
--- a/lib/service_objects/update_email_address.rb
+++ b/lib/service_objects/update_email_address.rb
@@ -3,13 +3,17 @@ module ServiceObjects
     def call
       # The ID hash does not come through with the hash of the person ids
       # So we have to make a work around for it.
-      biola_id = TrogdirPerson.new(change.person_uuid).biola_id
-      UpdateLegacyEmailTable.new(change).insert_and_update(biola_id, change.old_university_email, change.new_university_email)
+      if change.biola_id_updated?
+        UpdateLegacyEmailTable.new(change).insert_and_update_id(change.old_biola_id, change.new_biola_id)
+      else
+        biola_id = TrogdirPerson.new(change.person_uuid).biola_id
+        UpdateLegacyEmailTable.new(change).insert_and_update_address(biola_id, change.old_university_email, change.new_university_email)
+      end
       :update
     end
 
     def ignore?
-      !change.university_email_updated?
+      !(change.university_email_updated? || change.biola_id_updated?)
     end
   end
 end

--- a/lib/service_objects/update_legacy_email_table.rb
+++ b/lib/service_objects/update_legacy_email_table.rb
@@ -6,13 +6,17 @@ module ServiceObjects
       DB[:email].insert(idnumber: change.biola_id, email: email)
     end
 
-    def insert_and_update(biola_id, old_email, new_email)
+    def insert_and_update_address(biola_id, old_email, new_email)
       DB[:email].where(idnumber: biola_id, email: old_email).update(primary: 0)
       if DB[:email].where(idnumber: biola_id, email: new_email).count > 0
         DB[:email].where(idnumber: biola_id, email: new_email).update(primary: 1, expiration_date: "0000-00-00 00:00:00")
       else
         DB[:email].insert(idnumber: biola_id, email: new_email)
       end
+    end
+
+    def insert_and_update_id(old_id, new_id)
+      DB[:email].where(idnumber: old_id).update(idnumber: new_id) if DB[:email].where(idnumber: old_id).count > 0
     end
 
     def ignore?

--- a/lib/trogdir_change.rb
+++ b/lib/trogdir_change.rb
@@ -16,6 +16,18 @@ class TrogdirChange
     Array(all_attrs['ids']).find { |id| id['type'] == 'biola_id' }['identifier']
   end
 
+  def biola_id_updated?
+    biola_id? && update? && all_attrs['type'] == 'biola_id'
+  end
+
+  def old_biola_id
+    original['identifier']
+  end
+
+  def new_biola_id
+    modified['identifier']
+  end
+
   def preferred_name
     all_attrs['preferred_name']
   end
@@ -106,6 +118,10 @@ class TrogdirChange
 
   def email?
     hash['scope'] == 'email'
+  end
+
+  def biola_id?
+    hash['scope'] == 'id'
   end
 
   def create?

--- a/spec/fixtures/update_biola_id.json
+++ b/spec/fixtures/update_biola_id.json
@@ -1,0 +1,27 @@
+{
+   "sync_log_id":"000000000000000000000000",
+   "action":"update",
+   "person_id":"00000000-0000-0000-0000-000000000000",
+   "affiliations":[
+      "employee",
+      "faculty"
+   ],
+   "scope":"id",
+   "original":{
+      "identifier":"00000000",
+      "type":"biola_id"
+   },
+   "modified":{
+      "identifier":"0000000",
+      "type":"biola_id"
+   },
+   "all_attributes":{
+      "_id":{
+         "$oid":"000000000000000000000000"
+      },
+      "type":"biola_id",
+      "identifier":"0000000",
+      "version":2
+   },
+   "created_at":"2015-08-18T10:00:11.974-07:00"
+}

--- a/spec/lib/service_objects/handle_change_spec.rb
+++ b/spec/lib/service_objects/handle_change_spec.rb
@@ -36,8 +36,8 @@ describe ServiceObjects::HandleChange do
 
     it 'calls SyncGoogleAccount' do
       expect_any_instance_of(ServiceObjects::AssignEmailAddress).to_not receive(:call)
-      expect_any_instance_of(ServiceObjects::SyncGoogleAccount).to receive(:call).and_return(:update)
-      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :update)
+      expect_any_instance_of(ServiceObjects::SyncGoogleAccount).to receive(:call).and_return(:create)
+      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :create)
       expect(Workers::ChangeError).to_not receive(:perform_async)
 
       subject.call
@@ -49,8 +49,8 @@ describe ServiceObjects::HandleChange do
 
     it 'calls UpdateEmailAddress' do
       expect_any_instance_of(ServiceObjects::AssignEmailAddress).to_not receive(:call)
-      expect_any_instance_of(ServiceObjects::UpdateEmailAddress).to receive(:call).and_return(:create)
-      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :create)
+      expect_any_instance_of(ServiceObjects::UpdateEmailAddress).to receive(:call).and_return(:update)
+      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :update)
       expect(Workers::ChangeError).to_not receive(:perform_async)
 
       subject.call

--- a/spec/lib/service_objects/handle_change_spec.rb
+++ b/spec/lib/service_objects/handle_change_spec.rb
@@ -44,6 +44,19 @@ describe ServiceObjects::HandleChange do
     end
   end
 
+  context 'when biola id updated' do
+    let(:change_hash) { JSON.parse(File.read('./spec/fixtures/update_biola_id.json')) }
+
+    it 'calls UpdateEmailAddress' do
+      expect_any_instance_of(ServiceObjects::AssignEmailAddress).to_not receive(:call)
+      expect_any_instance_of(ServiceObjects::UpdateEmailAddress).to receive(:call).and_return(:create)
+      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :create)
+      expect(Workers::ChangeError).to_not receive(:perform_async)
+
+      subject.call
+    end
+  end
+
   context 'when account info updated' do
     let(:change_hash) { JSON.parse(File.read('./spec/fixtures/update_person.json')) }
 

--- a/spec/lib/service_objects/handle_change_spec.rb
+++ b/spec/lib/service_objects/handle_change_spec.rb
@@ -36,8 +36,8 @@ describe ServiceObjects::HandleChange do
 
     it 'calls SyncGoogleAccount' do
       expect_any_instance_of(ServiceObjects::AssignEmailAddress).to_not receive(:call)
-      expect_any_instance_of(ServiceObjects::SyncGoogleAccount).to receive(:call).and_return(:create)
-      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :create)
+      expect_any_instance_of(ServiceObjects::SyncGoogleAccount).to receive(:call).and_return(:update)
+      expect(Workers::ChangeFinish).to receive(:perform_async).with(kind_of(String), :update)
       expect(Workers::ChangeError).to_not receive(:perform_async)
 
       subject.call


### PR DESCRIPTION
in the WS Legacy Email Table.