### PR TITLE
Downcase emails when comparing against what google has

### DIFF
--- a/lib/google_account.rb
+++ b/lib/google_account.rb
@@ -17,7 +17,7 @@ class GoogleAccount
 
     return false unless result.success?
 
-    result.data.emails.map{|e| e['address']}.include? full_email
+    result.data.emails.map{|e| e['address'].downcase }.include? full_email.downcase
   end
 
   def available?


### PR DESCRIPTION
It has happened that the email in google is a different case that want we have in Trogdir.